### PR TITLE
fs_mgr: introduce fs_mgr_format to format wiped partitions

### DIFF
--- a/fs_mgr/Android.mk
+++ b/fs_mgr/Android.mk
@@ -4,8 +4,12 @@ LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES:= fs_mgr.c fs_mgr_verity.c fs_mgr_fstab.c
+LOCAL_SRC_FILES += fs_mgr_format.c
 
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/include \
+    system/vold \
+    system/extras/ext4_utils \
+    external/openssl/include
 
 LOCAL_MODULE:= libfs_mgr
 LOCAL_STATIC_LIBRARIES := liblogwrap libmincrypt libext4_utils_static
@@ -35,6 +39,7 @@ LOCAL_MODULE_PATH := $(TARGET_ROOT_OUT)/sbin
 LOCAL_UNSTRIPPED_PATH := $(TARGET_ROOT_OUT_UNSTRIPPED)
 
 LOCAL_STATIC_LIBRARIES := libfs_mgr liblogwrap libcutils liblog libc libmincrypt libext4_utils_static
+LOCAL_STATIC_LIBRARIES += libsparse_static libz libselinux
 
 LOCAL_CFLAGS := -Werror
 

--- a/fs_mgr/fs_mgr_format.c
+++ b/fs_mgr/fs_mgr_format.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <cutils/partition_utils.h>
+#include <sys/mount.h>
+#include "ext4_utils.h"
+#include "ext4.h"
+#include "make_ext4fs.h"
+#include "fs_mgr_priv.h"
+
+extern struct fs_info info;     /* magic global from ext4_utils */
+extern void reset_ext4fs_info();
+
+static int format_ext4(char *fs_blkdev, char *fs_mnt_point)
+{
+    unsigned int nr_sec;
+    int fd, rc = 0;
+
+    if ((fd = open(fs_blkdev, O_WRONLY, 0644)) < 0) {
+        ERROR("Cannot open block device.  %s\n", strerror(errno));
+        return -1;
+    }
+
+    if ((ioctl(fd, BLKGETSIZE, &nr_sec)) == -1) {
+        ERROR("Cannot get block device size.  %s\n", strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    /* Format the partition using the calculated length */
+    reset_ext4fs_info();
+    info.len = ((off64_t)nr_sec * 512);
+
+    /* Use make_ext4fs_internal to avoid wiping an already-wiped partition. */
+    rc = make_ext4fs_internal(fd, NULL, fs_mnt_point, 0, 0, 0, 0, 0, 0, 0, 0, NULL);
+    if (rc) {
+        ERROR("make_ext4fs returned %d.\n", rc);
+    }
+    close(fd);
+
+    return rc;
+}
+
+static int format_f2fs(char *fs_blkdev)
+{
+    char * args[3];
+    int pid;
+    int rc = 0;
+
+    args[0] = (char *)"/sbin/mkfs.f2fs";
+    args[1] = fs_blkdev;
+    args[2] = (char *)0;
+
+    pid = fork();
+    if (pid < 0) {
+       return pid;
+    }
+    if (!pid) {
+        /* This doesn't return */
+        execv("/sbin/mkfs.f2fs", args);
+        exit(1);
+    }
+    for(;;) {
+        pid_t p = waitpid(pid, &rc, 0);
+        if (p != pid) {
+            ERROR("Error waiting for child process - %d\n", p);
+            rc = -1;
+            break;
+        }
+        if (WIFEXITED(rc)) {
+            rc = WEXITSTATUS(rc);
+            INFO("%s done, status %d\n", args[0], rc);
+            if (rc) {
+                rc = -1;
+            }
+            break;
+        }
+        ERROR("Still waiting for %s...\n", args[0]);
+    }
+
+    return rc;
+}
+
+int fs_mgr_do_format(struct fstab_rec *fstab)
+{
+    int rc = -EINVAL;
+
+    ERROR("%s: Format %s as '%s'.\n", __func__, fstab->blk_device, fstab->fs_type);
+
+    if (!strncmp(fstab->fs_type, "f2fs", 4)) {
+        rc = format_f2fs(fstab->blk_device);
+    } else if (!strncmp(fstab->fs_type, "ext4", 4)) {
+        rc = format_ext4(fstab->blk_device, fstab->mount_point);
+    } else {
+        ERROR("File system type '%s' is not supported\n", fstab->fs_type);
+    }
+
+    return rc;
+}

--- a/fs_mgr/fs_mgr_fstab.c
+++ b/fs_mgr/fs_mgr_fstab.c
@@ -68,6 +68,7 @@ static struct flag_list fs_mgr_flags[] = {
     { "zramsize=",   MF_ZRAMSIZE },
     { "verify",      MF_VERIFY },
     { "noemulatedsd", MF_NOEMULATEDSD },
+    { "formattable", MF_FORMATTABLE },
     { "defaults",    0 },
     { 0,             0 },
 };
@@ -431,4 +432,9 @@ int fs_mgr_is_encryptable(struct fstab_rec *fstab)
 int fs_mgr_is_noemulatedsd(struct fstab_rec *fstab)
 {
     return fstab->fs_mgr_flags & MF_NOEMULATEDSD;
+}
+
+int fs_mgr_is_formattable(struct fstab_rec *fstab)
+{
+    return fstab->fs_mgr_flags & (MF_FORMATTABLE);
 }

--- a/fs_mgr/fs_mgr_priv.h
+++ b/fs_mgr/fs_mgr_priv.h
@@ -75,6 +75,7 @@
 #define MF_FORCECRYPT   0x400
 #define MF_NOEMULATEDSD 0x800 /* no emulated sdcard daemon, sd card is the only
                                  external storage */
+#define MF_FORMATTABLE  0x1000
 
 #define DM_BUF_SIZE 4096
 

--- a/fs_mgr/include/fs_mgr.h
+++ b/fs_mgr/include/fs_mgr.h
@@ -84,7 +84,11 @@ int fs_mgr_is_nonremovable(struct fstab_rec *fstab);
 int fs_mgr_is_verified(struct fstab_rec *fstab);
 int fs_mgr_is_encryptable(struct fstab_rec *fstab);
 int fs_mgr_is_noemulatedsd(struct fstab_rec *fstab);
+int fs_mgr_is_formattable(struct fstab_rec *fstab);
 int fs_mgr_swapon_all(struct fstab *fstab);
+
+int fs_mgr_do_format(struct fstab_rec *fstab);
+
 #ifdef __cplusplus
 }
 #endif

--- a/init/Android.mk
+++ b/init/Android.mk
@@ -45,7 +45,9 @@ LOCAL_STATIC_LIBRARIES := \
 	libc \
 	libselinux \
 	libmincrypt \
-	libext4_utils_static
+	libext4_utils_static \
+	libsparse_static \
+	libz
 
 LOCAL_ADDITIONAL_DEPENDENCIES += $(LOCAL_PATH)/Android.mk
 

--- a/init/devices.c
+++ b/init/devices.c
@@ -564,7 +564,7 @@ static void handle_device(const char *action, const char *devpath,
         make_device(devpath, path, block, major, minor, (const char **)links);
         if (links) {
             for (i = 0; links[i]; i++)
-                make_link(devpath, links[i]);
+                make_link_init(devpath, links[i]);
         }
     }
 

--- a/init/util.c
+++ b/init/util.c
@@ -335,7 +335,7 @@ void sanitize(char *s)
     }
 }
 
-void make_link(const char *oldpath, const char *newpath)
+void make_link_init(const char *oldpath, const char *newpath)
 {
     int ret;
     char buf[256];

--- a/init/util.h
+++ b/init/util.h
@@ -33,7 +33,7 @@ unsigned int decode_uid(const char *s);
 
 int mkdir_recursive(const char *pathname, mode_t mode);
 void sanitize(char *p);
-void make_link(const char *oldpath, const char *newpath);
+void make_link_init(const char *oldpath, const char *newpath);
 void remove_link(const char *oldpath, const char *newpath);
 int wait_for_file(const char *filename, int timeout);
 void open_devnull_stdio(void);


### PR DESCRIPTION
Move fastboot's format logic into fs_mgr, to consolidate the knowledge
about how to do this (and when to wipe metadata).

Try to format these formattable paritions if they are wiped.

If formatting fails, we will fall out to let recovery mode handle it.

Bug: 20082763
Change-Id: I397cc197550e78d932e8a154fd234695c46dbe7b